### PR TITLE
Closes #20 : Group rules into few categories by priority

### DIFF
--- a/ecs.yml
+++ b/ecs.yml
@@ -1,20 +1,6 @@
 imports:
-  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/symfony.yaml' }
-  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/clean-code.yaml' }
-  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/php70.yaml' }
-  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/php71.yaml' }
-  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/psr2.yaml' }
-
-services:
-  PhpCsFixer\Fixer\Import\OrderedImportsFixer:
-    sort_algorithm: 'length'
-  PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer: ~
-  PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer:
-    ensure_fully_multiline: false
-
-parameters:
-  skip:
-    PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer: ~
-    PhpCsFixer\Fixer\Phpdoc\PhpdocInlineTagFixer: ~
-    PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer: ~
-    PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer: ~
+  - { resource: 'standards/php.yaml' }
+  - { resource: 'standards/symfony.yaml' }
+  - { resource: 'standards/akeneo.yaml' }
+  - { resource: 'standards/clean-code.yaml' }
+  - { resource: 'standards/other.yaml' }

--- a/standards/akeneo.yaml
+++ b/standards/akeneo.yaml
@@ -1,0 +1,14 @@
+#
+# This file should contain up-to-date coding rules set by Akeneo core team. It should include the following:
+#
+#  Versioning and dependencies: https://docs.akeneo.com/master/technical_architecture/best_practices/project.html
+#  Bundle creation: https://docs.akeneo.com/master/technical_architecture/best_practices/reusable_bundle.html
+#  Code conventions: https://docs.akeneo.com/master/technical_architecture/best_practices/core/conventions.html
+#  Code standards: https://docs.akeneo.com/master/technical_architecture/best_practices/core/standards.html
+#
+services:
+  # https://docs.akeneo.com/master/technical_architecture/best_practices/core/standards.html
+
+  # Add a single space around operators (==, &&, …);
+  PhpCsFixer\Fixer\Operator\ConcatSpaceFixer:
+    spacing: one

--- a/standards/clean-code.yaml
+++ b/standards/clean-code.yaml
@@ -1,0 +1,7 @@
+#
+# This file should contain up-to-date coding practices covered by these clean code books:
+#  https://www.amazon.com/Robert-C.-Martin/e/B000APG87E
+# and any other content of "clean code" movement that do not contradict the current message of the author.
+#
+imports:
+  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/clean-code.yaml' }

--- a/standards/other.yaml
+++ b/standards/other.yaml
@@ -1,0 +1,20 @@
+#
+# There should be nothing in this file that contradicts standards provided by all others, e.g. PHP-FIG, Symfony, etc.
+# Therefore it is really under the question if we should have any content in here at all.
+#
+# In practice, the rule here must match any of issues: https://github.com/digitronas/akeneo-coding-standard/issues
+# Therefore it is advisable to provide a link to the coresponding issue after providing the rule itself.
+#
+#services:
+#  PhpCsFixer\Fixer\Import\OrderedImportsFixer:
+#    sort_algorithm: 'length'
+#  PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer: ~
+#  PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer:
+#    ensure_fully_multiline: false
+#
+#parameters:
+#  skip:
+#    PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer: ~
+#    PhpCsFixer\Fixer\Phpdoc\PhpdocInlineTagFixer: ~
+#    PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer: ~
+#    PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer: ~

--- a/standards/php.yaml
+++ b/standards/php.yaml
@@ -1,0 +1,9 @@
+#
+# This file should contain up-to-date coding rules set by PHP.
+#  It excludes PHP legacy usage, e.g.: https://www.php.net/manual/en/migration70.deprecated.php
+#  and includes best practices presented by PHP-FIG personnel in the form of PSRs: https://www.php-fig.org/psr/
+#
+imports:
+  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/php70.yaml' }
+  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/php71.yaml' }
+  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/psr12.yaml' }

--- a/standards/symfony.yaml
+++ b/standards/symfony.yaml
@@ -1,0 +1,6 @@
+#
+# This file should contain up-to-date coding rules set by Symfony core team. It should include the following:
+#  https://symfony.com/doc/master/contributing/code/standards.html
+#
+imports:
+  - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/symfony.yaml' }


### PR DESCRIPTION
Group rules into few categories by priority, disable rules that contradicts standards or falls into discussable "other" category (these may come back after discussed), change psr2 to psr12 (psr12 includes compatible part of psr2, psr2 is deprecated as of 2019-08-10).