### PR TITLE
Restrict the usage of issue references

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Clone this repository and run `composer install`. This will install ecs and grum
 
 Create a pull request to `master` branch. The changes will be merged after they pass code review.
 
-If an issue should be closed once a pull request is merged, it can be done automatically using Github issue references. Add "Closes #{issue number}" to description. References should not appear in pull request title or any of its commits.
+If an issue should be closed once a pull request is merged, it can be done automatically using Github issue references. Add "Closes #{issue number}" to description ([example](https://github.com/digitronas/akeneo-coding-standard/pull/5)). References should not appear in pull request title or any of its commits.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ To add or remove rules, first [submit an issue](https://github.com/digitronas/ak
 Clone this repository and run `composer install`. This will install ecs and grumphp. You might have to [bypass grumphp](https://github.com/phpro/grumphp/blob/master/doc/faq.md#how-can-i-bypass-grumphp), since it might not allow you to commit code if there are files that don't meet the standard.
 
 Create a pull request to `master` branch. The changes will be merged after they pass code review.
+
+If an issue should be closed once a pull request is merged, it can be done automatically using Github issue references. Add "Closes #{issue number}" to description. References should not appear in pull request title or any of its commits.

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Clone this repository and run `composer install`. This will install ecs and grum
 
 Create a pull request to `master` branch. The changes will be merged after they pass code review.
 
-If an issue should be closed once a pull request is merged, it can be done automatically using Github issue references. Add "Closes #{issue number}" to description ([example](https://github.com/digitronas/akeneo-coding-standard/pull/5)). References should not appear in pull request title or any of its commits.
+If an issue should be closed once a pull request is merged, it can be done automatically using Github issue references. To do that, follow [Github tutorial](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords). (here's an [example](https://github.com/digitronas/akeneo-coding-standard/pull/5)). Only pull requests can use references to close issues. Commit messages may contain references, but they must never close issues. Also, *closing* references should be in the pull request description, not the title.


### PR DESCRIPTION
Mandates how we should use github's issue references like *Closes #X*.